### PR TITLE
Add setup instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@ This is the group project from the Turing School of Software and Design's Mod 2.
 - Incorporate Webpack to streamline your workflow process
 - Leverage Chai Spies to verify that your DOM manipulation is happening
 
-## Setup
+## Setup Instructions
 
-# not sure what to put here!
+Local Server Instructions:
+- Clone this repo
+- In the directory, run `npm install`
+- Once `npm` is installed, run `npm start` in your terminal
+- Keep the terminal running in the background and go to `http://localhost:8080/` in your browser
+- When you are done, enter `control + c` in the terminal to stop the server
+
 
 ## Contributors
 


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features

### Detailed Description
Added setup instructions to README for local server.

### Why is this change required? What problem does it solve?
This adds the setup instructions, so the README is done. 

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
We couldn't get the GitHub Pages deployment to work.

### Files modified:
- [ ] index.html
- [ ] styles.css
- [ ] main.js
- [x] Other files:
`README.md`
